### PR TITLE
Change 'Readme.md' to 'README.md' for example files

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -28,7 +28,9 @@ const DEFAULT_CONFIG = {
 	highlightTheme: 'base16-light',
 	verbose: false,
 	getExampleFilename: (componentpath, fileName) => {
-		fileName = fileName ? fileName : 'Readme.md';
+		// Careful: Mobify decision to use README.md. On some systems (Linux) the filesystem
+		//          is case sensitive and so the files in git _must_ match this casing.
+		fileName = fileName ? fileName : 'README.md';
 
 		return path.join(path.dirname(componentpath), fileName);
 	},


### PR DESCRIPTION
Styleguidist finds `Readme.md` files in the component directories and provides the contents as live code examples (playgrounds). On Mac systems the name of the file is case insensitive and the casing of the filename is flexible. On Linux systems (CircleCI) the filesystem _is_ case sensitive and so we have to match the filename (and casing) exactly. 

This PR shifts the filename to be `README.md` (all caps) as that's what the progressive-web-sdk has already settled on.