### PR TITLE
Cleanup Props table styles

### DIFF
--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -23,6 +23,11 @@
 }
 
 .root :global .rsg-code-props-table-row td:nth-child(3) code {
+    /**
+	 * Prevent the prop's default cell from growing too large and making it
+	 * unreadable! It won't be readable very easily for large defaults, but it
+	 * can be copy/pasted. Open to other ideas!
+	 */
     display: block;
     overflow: hidden;
     max-width: 60px;

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -10,7 +10,7 @@
     text-transform: uppercase;
 }
 
-.root :global .rsg-code-props-table-row {
+.root :global .rsg-code-props-table-row--top {
     border-top: 1px solid rgba(0, 0, 0, 0.03);
 }
 

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -1,4 +1,4 @@
-.root :global .rsg-code-props-table {
+.root:global.rsg-code-props-table {
     font-size: 12px;
 }
 

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -10,8 +10,12 @@
     text-transform: uppercase;
 }
 
-.root :global .rsg-code-props-table-row--top {
+.root :global .rsg-code-props-table-row {
     border-top: 1px solid rgba(0, 0, 0, 0.03);
+}
+
+.root :global .rsg-code-props-table-description {
+    margin-top: 6px;
 }
 
 .root :global .rsg-code-props-table-row td {

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -30,8 +30,4 @@
 	 */
     display: block;
     overflow: hidden;
-    max-width: 60px;
-
-    white-space: nowrap;
-    text-overflow: ellipsis;
 }

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -1,15 +1,32 @@
-.root :global .rsg-code-props-table-heading-row th:nth-child(2){
-    display: none;
+.root :global .rsg-code-props-table {
+    font-size: 12px;
 }
 
-.root :global .rsg-code-props-table-heading-row th:nth-child(3){
-    display: none;
+.root :global .rsg-code-props-table-heading-row th {
+    padding: 12px 0;
+
+    font-size: 10px;
+    text-align: left;
+    text-transform: uppercase;
 }
 
-.root :global .rsg-code-props-table-row td:nth-child(2){
-    display: none;
+.root :global .rsg-code-props-table-row {
+    border-top: 1px solid rgba(0, 0, 0, 0.03);
 }
 
-.root :global .rsg-code-props-table-row td:nth-child(3){
-    display: none;
+.root :global .rsg-code-props-table-row td {
+    padding: 6px 0;
+}
+
+.root :global .rsg-code-props-table-row td:not(:last-of-type) {
+    padding-right: 12px;
+}
+
+.root :global .rsg-code-props-table-row td:nth-child(3) code {
+    display: block;
+    overflow: hidden;
+    max-width: 60px;
+
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -10,10 +10,12 @@ function renderRows(props) {
 	for (let name in props) {
 		let prop = props[name];
 		rows.push(
-			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={name}>
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row" key={name}>
 				<td>
 					<Code>{name}</Code>
-					<div>{renderDescription(prop)}</div>
+					<div className="rsg-code-props-table-description">
+						{renderDescription(prop)}
+					</div>
 				</td>
 				<td><Code>{renderType(getType(prop))}</Code></td>
 				<td>{renderDefault(prop)}</td>

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -10,14 +10,14 @@ function renderRows(props) {
 	for (let name in props) {
 		let prop = props[name];
 		const topRow = (
-			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={name}>
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={`${name}-top`}>
 				<td><Code>{name}</Code></td>
 				<td><Code>{renderType(getType(prop))}</Code></td>
 				<td>{renderDefault(prop)}</td>
 			</tr>
 		)
 		const bottomRow = (
-			<tr className="rsg-code-props-table-row rsg-code-props-table-row--bottom" key={name}>
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row--bottom" key={`${name}-bottom`}>
 				<td>{renderDescription(prop)}</td>
                 <td colspan="2"></td>
 			</tr>

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -10,11 +10,16 @@ function renderRows(props) {
 	for (let name in props) {
 		let prop = props[name];
 		rows.push(
-			<tr className="rsg-code-props-table-row" key={name}>
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={name}>
 				<td><Code>{name}</Code></td>
 				<td><Code>{renderType(getType(prop))}</Code></td>
 				<td>{renderDefault(prop)}</td>
+			</tr>
+		);
+        rows.push(
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row--bottom" key={name}>
 				<td>{renderDescription(prop)}</td>
+                <td colspan="2"></td>
 			</tr>
 		);
 	}

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -138,7 +138,7 @@ function renderShape(props) {
 
 export default function PropsRenderer({ props }) {
 	return (
-		<table className={s.root}>
+		<table className={s.root + ' rsg-code-props-table'}>
 			<thead>
 				<tr className="rsg-code-props-table-heading-row">
 					<th>Name</th>

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -9,19 +9,20 @@ function renderRows(props) {
 	let rows = [];
 	for (let name in props) {
 		let prop = props[name];
-		rows.push(
+		const topRow = (
 			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={name}>
 				<td><Code>{name}</Code></td>
 				<td><Code>{renderType(getType(prop))}</Code></td>
 				<td>{renderDefault(prop)}</td>
 			</tr>
-		);
-        rows.push(
+		)
+		const bottomRow = (
 			<tr className="rsg-code-props-table-row rsg-code-props-table-row--bottom" key={name}>
 				<td>{renderDescription(prop)}</td>
                 <td colspan="2"></td>
 			</tr>
-		);
+		)
+		rows.push(topRow, bottomRow);
 	}
 	return rows;
 }
@@ -149,7 +150,6 @@ export default function PropsRenderer({ props }) {
 					<th>Name</th>
 					<th>Type</th>
 					<th>Default</th>
-					<th>Description</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -9,20 +9,16 @@ function renderRows(props) {
 	let rows = [];
 	for (let name in props) {
 		let prop = props[name];
-		const topRow = (
-			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={`${name}-top`}>
-				<td><Code>{name}</Code></td>
+		rows.push(
+			<tr className="rsg-code-props-table-row rsg-code-props-table-row--top" key={name}>
+				<td>
+					<Code>{name}</Code>
+					<div>{renderDescription(prop)}</div>
+				</td>
 				<td><Code>{renderType(getType(prop))}</Code></td>
 				<td>{renderDefault(prop)}</td>
 			</tr>
-		)
-		const bottomRow = (
-			<tr className="rsg-code-props-table-row rsg-code-props-table-row--bottom" key={`${name}-bottom`}>
-				<td>{renderDescription(prop)}</td>
-                <td colspan="2"></td>
-			</tr>
-		)
-		rows.push(topRow, bottomRow);
+		);
 	}
 	return rows;
 }


### PR DESCRIPTION
Reveal the missing `type` and `default` columns, reduce font size, and make the props table generally more readable.

| Before | After |
| --- | --- |
| ![before](https://cloud.githubusercontent.com/assets/734535/26601385/840117ec-4534-11e7-8e94-5c0fbae25dea.png) | ![after](https://user-images.githubusercontent.com/734535/27454137-c08ed6ba-574d-11e7-9f63-6c9e93f88b5f.png) |


## How To Test

1. Open `package.json` in your `platform-scaffold` repo
2. Alter the `react-styleguidist` dependency to depend on `"react-styleguidist": "https://github.com/mobify/react-styleguidist.git#expand-props-tables"`
3. In the `platform-scaffold` direction, run `rm -r node_modules/react-styleguidist`
4. Run `npm i`
5. Run `npm run docs:dev`
6. Visit [http://localhost:9000/latest/components/#](http://localhost:9000/latest/components/#)
7. **Verify** that the component table appears as seen in the "after" screenshot above.