### PR TITLE
remove margin-top:0 to make heading work in components

### DIFF
--- a/src/rsg-components/Markdown/Markdown.css
+++ b/src/rsg-components/Markdown/Markdown.css
@@ -17,7 +17,6 @@
 .h5,
 .h6 {
 	composes: font from "../../styles/common.css";
-	margin-top: 0;
 	margin-bottom: 15px;
 }
 


### PR DESCRIPTION
Status: **Ready for Review**

## Changes
- remove margin-top:0 for `p` tag

## How to Test
1. Open `package.json` in your `sdk` repo
2. Alter the `react-styleguidist` dependency to depend on `"react-styleguidist": "https://github.com/mobify/react-styleguidist.git#remove-p-margin"`
3. In the `sdk` directory, run `rm -r node_modules/react-styleguidist`
4. Run `npm i`
5. Run `npm run docs:dev`
6. Visit [http://localhost:9000/latest/components/#](http://localhost:9000/latest/components/#)
7. check a few components styles